### PR TITLE
relocate status output

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -474,9 +474,6 @@ protected
     [method, method+".exe"].each do |cmd|
       if command_passthru && Rex::FileUtils.find_full_path(cmd)
 
-        print_status("exec: #{line}")
-        print_line('')
-
         self.busy = true
         begin
           run_unknown_command(line)
@@ -501,6 +498,8 @@ protected
   end
 
   def run_unknown_command(command)
+    print_status("exec: #{command}")
+    print_line('')
     system(command)
   end
 


### PR DESCRIPTION
relocate the status output preceding the execution of the passthough command to the new run_unknown_command method.  This output will generate unwanted noise at the beginning of the command output in the msg buffer in a web console, but will preserve existing behaviour with passthough command execution in msfconsole.